### PR TITLE
Don't overwrite communities w/ blank extended communities list

### DIFF
--- a/nest/rt-table.c
+++ b/nest/rt-table.c
@@ -1311,7 +1311,7 @@ rte_dump(rte *e)
 				  memcpy(aspath, attr_buf, sizeof(aspath));
 			  //else if (strstr(buf, "next_hop")) 
 			  //memcpy(nexthop, attr_buf, sizeof(nexthop));
-			  else if (strstr(buf, "community"))
+			  else if (!memcmp(buf, "community", strlen("community")))
 				  memcpy(community, attr_buf, sizeof(community));
 		  }
 


### PR DESCRIPTION
See https://deepfield.atlassian.net/browse/SUP-282

https://deepfield.atlassian.net/browse/SUP-282?focusedCommentId=13589&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13589

"ext-community", w/ empty attr bufferm was overwriting "community" string.
