### PR TITLE
Bird CRAN BGP

### DIFF
--- a/nest/config.Y
+++ b/nest/config.Y
@@ -626,8 +626,8 @@ CF_CLI(DUMP NEIGHBORS,,, [[Dump neighbor cache]])
 { neigh_dump_all(); cli_msg(0, ""); } ;
 CF_CLI(DUMP ATTRIBUTES,,, [[Dump attribute cache]])
 { rta_dump_all(); cli_msg(0, ""); } ;
-CF_CLI(DUMP ROUTES,,, [[Dump routing table]])
-{ rt_dump_all(); cli_msg(0, ""); } ;
+CF_CLI(DUMP ROUTES, text, <output-dir>, [[Dump routing table]])
+{ rt_dump_all($3); cli_msg(0, ""); } ;
 CF_CLI(DUMP PROTOCOLS,,, [[Dump protocol information]])
 { protos_dump_all(); cli_msg(0, ""); } ;
 

--- a/nest/route.h
+++ b/nest/route.h
@@ -270,8 +270,8 @@ void rte_dump(rte *, FILE *);
 void rte_free(rte *);
 rte *rte_do_cow(rte *);
 static inline rte * rte_cow(rte *r) { return (r->flags & REF_COW) ? rte_do_cow(r) : r; }
-void rt_dump(rtable *);
-void rt_dump_all(void);
+void rt_dump(rtable *, const char *);
+void rt_dump_all(const char *);
 int rt_feed_baby(struct proto *p);
 void rt_feed_baby_abort(struct proto *p);
 int rt_prune_loop(void);

--- a/nest/route.h
+++ b/nest/route.h
@@ -13,6 +13,7 @@
 #include "lib/resource.h"
 #include "lib/timer.h"
 #include "nest/protocol.h"
+#include <stdio.h>
 
 struct protocol;
 struct proto;
@@ -265,7 +266,7 @@ void rte_discard(rtable *tab, rte *old);
 int rt_examine(rtable *t, ip_addr prefix, int pxlen, struct proto *p, struct filter *filter);
 void rt_refresh_begin(rtable *t, struct announce_hook *ah);
 void rt_refresh_end(rtable *t, struct announce_hook *ah);
-void rte_dump(rte *);
+void rte_dump(rte *, FILE *);
 void rte_free(rte *);
 rte *rte_do_cow(rte *);
 static inline rte * rte_cow(rte *r) { return (r->flags & REF_COW) ? rte_do_cow(r) : r; }

--- a/nest/rt-table.c
+++ b/nest/rt-table.c
@@ -1510,12 +1510,12 @@ rt_dump(rtable *t, const char *dump_dir)
   //debug("\n");
 
   for (idx = 0; idx < dc->hash_nbuckets; idx++) {
-	  for (de = dc->hash_table[idx]; de != NULL; de = de->next) {
-		 if (de->fp != NULL) {
-			 fclose(de->fp);
-			 rename(de->tmpfilename, de->filename);
-		 }
-	  }
+    for (de = dc->hash_table[idx]; de != NULL; de = de->next) {
+      if (de->fp != NULL) {
+        fclose(de->fp);
+        rename(de->tmpfilename, de->filename);
+      }
+    }
   }
 
   debug("end-dump: %s\n", buffer);

--- a/nest/rt-table.c
+++ b/nest/rt-table.c
@@ -42,10 +42,15 @@
 #include "filter/filter.h"
 #include "lib/string.h"
 #include "lib/alloca.h"
+#include <assert.h>
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 #include <signal.h>
+
+pid_t parent_pid = 0;
 
 pool *rt_table_pool;
 
@@ -62,8 +67,6 @@ static void rt_next_hop_update(rtable *tab);
 static inline int rt_prune_table(rtable *tab);
 static inline void rt_schedule_gc(rtable *tab);
 static inline void rt_schedule_prune(rtable *tab);
-
-static FILE *fp = NULL;
 
 static inline struct ea_list *
 make_tmp_attrs(struct rte *rt, struct linpool *pool)
@@ -1189,13 +1192,140 @@ craig_show_int_set(struct adata *ad, int way, byte *pos, byte *buf, byte *end)
 }
 
 /**
+ * Mapping from neighbor IPs to dump file pointers
+ */
+
+struct dumpfile_entry {
+	struct dumpfile_entry *next;
+	ip_addr	neighbor;
+	FILE *fp;
+	unsigned hash_key;
+	char *filename;
+	char *tmpfilename;
+};
+
+struct dumpfile_cache {
+	struct	dumpfile_entry **hash_table;
+	unsigned	hash_order;
+	unsigned	hash_shift;
+	unsigned	hash_nbuckets;
+};
+
+static struct dumpfile_cache *
+init_dumpfile_cache(void)
+{
+	unsigned	order;
+	unsigned	nbuckets;
+	struct dumpfile_cache *dc = calloc(1, sizeof(struct dumpfile_cache));
+
+	order = 10;
+	nbuckets = 1 << order;
+	dc->hash_order = order;
+	dc->hash_shift = 16 - order;
+	dc->hash_table = calloc(nbuckets, sizeof(struct dumpfile_entry *));
+	dc->hash_nbuckets = nbuckets;
+
+	return dc;
+}
+
+static inline unsigned
+de_hash(ip_addr neighbor)
+{
+	return ipa_hash(neighbor) & 0xffff;
+}
+
+static inline void
+dc_insert(struct dumpfile_cache *dc, struct dumpfile_entry *de)
+{
+	unsigned int	k;
+
+	k = de->hash_key >> dc->hash_shift;
+	de->next = dc->hash_table[k];
+	dc->hash_table[k] = de;
+}
+
+static struct dumpfile_entry *
+dc_get_dumpfile_entry(struct dumpfile_cache *dc, ip_addr neighbor,
+		      unsigned int k)
+{
+	struct dumpfile_entry	*next = NULL;
+	struct dumpfile_entry	*de = NULL;
+	unsigned int		bucket;
+
+	bucket = k >> dc->hash_shift;
+	assert(bucket < dc->hash_nbuckets);
+	for (next = dc->hash_table[bucket]; next != NULL; next = next->next) {
+		if (ipa_equal(next->neighbor, neighbor)) {
+			de = next;
+			break;
+		}
+	}
+
+	return de;
+}
+
+static void
+get_dump_filename(char *buffer, size_t buflen, ip_addr neighbor,
+		  pid_t ppid, const char *suffix)
+{
+	byte	from[STD_ADDRESS_P_LENGTH+2];
+
+	bsprintf(from, "%I", neighbor);
+	snprintf(buffer, buflen, "/pipedream/bgp/dumps/local_bgpdump."
+			         "%d.%s.txt%s", ppid, from, suffix);
+}
+
+static FILE *
+open_dump_file(const char *filename) {
+	FILE *fp;
+	fp = fopen(filename, "w+");
+	if (fp == NULL) {
+		debug("failed-to-open-dump-file %s: %s\n", filename,
+		      strerror(errno));
+	}
+	else {
+		debug("start-dump-file: %s\n", filename);
+	}
+
+	return fp;
+}
+
+static FILE *
+dc_get_neighbor_fp(struct dumpfile_cache *dc, ip_addr neighbor)
+{
+	char buffer[1024];
+	struct dumpfile_entry	*de = NULL;
+	unsigned int		k;
+
+	k = de_hash(neighbor);
+	de = dc_get_dumpfile_entry(dc, neighbor, k);
+
+	if (de == NULL) {
+		de = calloc(1, sizeof(struct dumpfile_entry));
+		de->neighbor = neighbor;
+		de->hash_key = k;
+		dc_insert(dc, de);
+		get_dump_filename(buffer, sizeof(buffer), neighbor,
+				  parent_pid, ".tmp");
+		de->tmpfilename = strdup(buffer);
+		de->fp = open_dump_file(de->tmpfilename);
+		get_dump_filename(buffer, sizeof(buffer), neighbor,
+				  parent_pid, "");
+		de->filename = strdup(buffer);
+	}
+
+	return de->fp;
+}
+
+
+/**
  * rte_dump - dump a route
  * @e: &rte to be dumped
  *
  * This functions dumps contents of a &rte to debug output.
  */
 void
-rte_dump(rte *e)
+rte_dump(rte *e, FILE *fp)
 {
   net *n = e->net;
 
@@ -1338,11 +1468,14 @@ rt_dump(rtable *t)
 {
   rte *e;
   net *n;
+  int idx;
   struct announce_hook *a;
-  char	buffer_tmp[1024];
+  struct dumpfile_cache *dc;
+  struct dumpfile_entry *de;
   char	buffer[1024];
+  FILE *fp;
   
-  int pid, parent_pid;
+  int pid;
 
   // make sure we don't have defunct children
   signal(SIGCHLD, SIG_IGN);
@@ -1352,12 +1485,8 @@ rt_dump(rtable *t)
   pid = fork();
   if (pid > 0)
 	  return;
-  
-  snprintf(buffer_tmp, sizeof(buffer_tmp), "/pipedream/cache/bgp/dumps/local_bgpdump.%d.txt.tmp", parent_pid);
-  snprintf(buffer, sizeof(buffer), "/pipedream/cache/bgp/dumps/local_bgpdump.%d.txt", parent_pid);
 
-  fp = fopen(buffer_tmp, "w+");
-  debug("start-dump: %s\n", buffer);
+  dc = init_dumpfile_cache();
 
   debug("Dump of routing table <%s>\n", t->name);
 #ifdef DEBUGGING
@@ -1367,15 +1496,26 @@ rt_dump(rtable *t)
     {
       n = (net *) fn;
       for(e=n->routes; e; e=e->next)
-	rte_dump(e);
+	  fp = dc_get_neighbor_fp(dc, e->attrs->from);
+	  if (fp == NULL) {
+		  continue;
+	  }
+	rte_dump(e, dc);
     }
   FIB_WALK_END;
   //WALK_LIST(a, t->hooks)
   //debug("\tAnnounces routes to protocol %s\n", a->proto->name);
   //debug("\n");
 
-  fclose(fp);
-  rename(buffer_tmp, buffer);
+  for (idx = 0; idx < dc->hash_nbuckets; idx++) {
+	  for (de = dc->hash_table[idx]; de != NULL; de = de->next) {
+		 if (de->fp != NULL) {
+			 fclose(de->fp);
+			 rename(de->tmpfilename, de->filename);
+		 }
+	  }
+  }
+
   debug("end-dump: %s\n", buffer);
   exit(0);
 

--- a/proto/rip/rip.c
+++ b/proto/rip/rip.c
@@ -57,6 +57,7 @@
 #include "lib/lists.h"
 #include "lib/timer.h"
 #include "lib/string.h"
+#include <stdio.h>
 
 #include "rip.h"
 
@@ -546,7 +547,7 @@ rip_timer(timer *t)
 
     CHK_MAGIC;
 
-    DBG( "Garbage: (%p)", rte ); rte_dump( rte );
+    DBG( "Garbage: (%p)", rte ); rte_dump( rte, stderr );
 
     if (now - rte->lastmod > P_CF->timeout_time) {
       TRACE(D_EVENTS, "entry is too old: %I", rte->net->n.prefix );

--- a/sysdep/unix/krt.c
+++ b/sysdep/unix/krt.c
@@ -554,7 +554,7 @@ krt_dump(struct proto *P)
   if (!KRT_CF->learn)
     return;
   debug("KRT: Table of inheritable routes\n");
-  rt_dump(&p->krt_table);
+  rt_dump(&p->krt_table, "./");
 }
 
 static void

--- a/sysdep/unix/main.c
+++ b/sysdep/unix/main.c
@@ -58,7 +58,7 @@ async_dump(void)
   if_dump_all();
   neigh_dump_all();
   rta_dump_all();
-  rt_dump_all();
+  rt_dump_all("./");
   protos_dump_all();
 
   debug("\n");


### PR DESCRIPTION
- Individual dump for each router.
- --dump command now takes dir to dump these all to

Caveats -

There were some existing none-CLI calls to the dump code, which I don't think we ever hit.  I defaulted the dump dir to CWD for those.

Existing code was a mix of tabs and spaces.  Tried to match style of any modified existing function, new functions are tabs.

Hash doesn't free memory for provide 'remove' methods, but only lives in a short-lived fork of bird during dump.
